### PR TITLE
removes Item.destroy_all from seeds.rb

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,7 +14,7 @@ ItemOrder.destroy_all
 Cart.destroy_all
 Category.destroy_all
 Order.destroy_all
-Item.destroy_all
+# Item.destroy_all
 User.destroy_all
 
 giphy_response =


### PR DESCRIPTION
Just removes the Item.destroy_all so we can all seed 100x gifs this morning; I'd like it if one of y'all did the project review so we'll need to seed twice over a few hour period